### PR TITLE
Fixing left-over glitches from refactoring

### DIFF
--- a/lib/comm.js
+++ b/lib/comm.js
@@ -143,7 +143,7 @@ Communication.prototype.reset = function() {
 
 Communication.prototype.getQueue = function(name) {
     if (!this.queues[name]) {
-        this.queues[name] = new Queue();
+        this.queues[name] = new Queue(name);
     }
     return this.queues[name];
 }
@@ -179,8 +179,8 @@ Queue.prototype.hasNext = function () {
 Queue.prototype.toPollString = function () {
     var name = this._name;
     var poll = "";
-    poll += pollArgs( this._crnt, this.name + '-crnt-');
-    poll += pollArgs( this._last, this.name + '-last-');
+    poll += pollArgs( this._crnt, name + '-crnt-');
+    poll += pollArgs( this._last, name + '-last-');
     poll += name + '-ptr '  + this._ptr  + '\n';
     poll += name + '-top '  + this._top  + '\n';
     poll += name + '-hasNext '  + this.hasNext() + '\n';
@@ -190,9 +190,10 @@ Queue.prototype.toPollString = function () {
 
 //------------ helper functions assembling 'poll' body
 
-function pollString(s) {
+function pollSafe(s) {
     s = s || "";
     if (typeof s != "string") {return s;}
+    s = decodeURIComponent(s);
     s = s.replace(/ /g, '_'); //Sadly the poll response does not properly support spaces.
     return encodeURIComponent(s);
 }
@@ -200,7 +201,7 @@ function pollString(s) {
 function pollArgs(set, pfx) {
     var poll = "";
     for (k in set) {
-        poll += pfx + k + " " + pollString(set[k]) + '\n';
+        poll += pfx + k + " " + pollSafe(set[k]) + '\n';
     }
     return poll;
 }


### PR DESCRIPTION
Didn't get the instance variable queue-name right. Leading to no longer working communication.

Also the path-segments are no longer uri-decoded from the URI we get them from.  By still simply encoding them before putting in the /poll result the end-result was a double-uri encoding making space become %20 and finally %2520
